### PR TITLE
Rx friendly presenters

### DIFF
--- a/src/main/java/com/xemantic/githubusers/logic/error/ErrorAnalyzer.java
+++ b/src/main/java/com/xemantic/githubusers/logic/error/ErrorAnalyzer.java
@@ -1,0 +1,41 @@
+/*
+ * github-users - lists GitHub users. Minimal app demonstrating
+ * cross-platform app development (Web, Android, iOS) where core
+ * logic is shared and transpiled from Java to JavaScript and
+ * Objective-C. This project delivers core application logic.
+ *
+ * Copyright (C) 2017  Kazimierz Pogoda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.xemantic.githubusers.logic.error;
+
+/**
+ * Analyzes {@link Throwable}s occurring in the streams of observed data.
+ * The result can be used to retry after recoverable error like temporal connection error.
+ */
+public interface ErrorAnalyzer {
+
+  /**
+   * Tells if supplied {@code throwable} is non-critical and therefore if action
+   * can possibly succeed on the next try. Examples: rate limit quota reached,
+   * connectivity problem, etc.
+   *
+   * @param throwable the error to analyze.
+   * @return the {@code true} if recoverable, {@code false} otherwise.
+   */
+  boolean isRecoverable(Throwable throwable);
+
+}

--- a/src/main/java/com/xemantic/githubusers/logic/presenter/DrawerPresenter.java
+++ b/src/main/java/com/xemantic/githubusers/logic/presenter/DrawerPresenter.java
@@ -30,39 +30,27 @@ import com.xemantic.githubusers.logic.view.DrawerView;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-/**
- * Presenter of the {@link DrawerView}.
- *
- * @author morisil
- */
-public class DrawerPresenter {
+public class DrawerPresenter extends Presenter<DrawerView> {
 
-  private final String projectUrl;
-
-  private final Sink<SnackbarMessageEvent> snackbarMessageSink;
-
-  private final UrlOpener urlOpener;
-
-  @Inject
-  public DrawerPresenter(
+  @Inject DrawerPresenter(
+      DrawerView view,
       @Named("projectGitHubUrl") String projectUrl,
       Sink<SnackbarMessageEvent> snackbarMessageSink,
-      UrlOpener urlOpener) {
+      UrlOpener urlOpener
+  ) {
+    super(view);
 
-    this.projectUrl = projectUrl;
-    this.snackbarMessageSink = snackbarMessageSink;
-    this.urlOpener = urlOpener;
-  }
+    register(view.observeOpenDrawerIntent().doOnNext(t -> view.openDrawer(true)));
 
-  public void start(DrawerView view) {
-    view.observeOpenDrawerIntent().subscribe(t -> view.openDrawer(true));
-    view.observeReadAboutIntent().subscribe(t -> snackbarMessageSink.publish(
-        new SnackbarMessageEvent("To be implemented soon"))
-    );
-    view.observeOpenProjectOnGitHubIntent().subscribe(t -> urlOpener.openUrl(projectUrl));
-    view.observeSelectLanguageIntent().subscribe(t -> snackbarMessageSink.publish(
-        new SnackbarMessageEvent("To be implemented soon"))
-    );
+    register(view.observeReadAboutIntent()
+        .map(ev -> new SnackbarMessageEvent("To be implemented soon"))
+        .doOnNext(snackbarMessageSink::publish));
+
+    register(view.observeOpenProjectOnGitHubIntent().doOnNext(t -> urlOpener.openUrl(projectUrl)));
+
+    register(view.observeSelectLanguageIntent()
+        .map(ev -> new SnackbarMessageEvent("To be implemented soon"))
+        .doOnNext(snackbarMessageSink::publish));
   }
 
 }

--- a/src/main/java/com/xemantic/githubusers/logic/presenter/Presenter.java
+++ b/src/main/java/com/xemantic/githubusers/logic/presenter/Presenter.java
@@ -1,0 +1,57 @@
+package com.xemantic.githubusers.logic.presenter;
+
+import io.reactivex.Observable;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.PublishSubject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static io.reactivex.Observable.range;
+import static io.reactivex.Observable.timer;
+import static io.reactivex.internal.functions.Functions.identity;
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Math.min;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public abstract class Presenter<V> {
+  private final List<Disposable> attachSubscriptions = new ArrayList<>();
+  private final List<Observable<?>> attachObservables = new ArrayList<>();
+  private final PublishSubject<Map<String, Object>> request$ = PublishSubject.create();
+  protected final V view;
+
+  public Presenter(V view) {
+    this.view = view;
+  }
+
+  public void register(Observable<?> o) {
+    assert !attachObservables.contains(o) : "duplicate subscription, pretty sure this is a bug";
+    attachObservables.add(o);
+  }
+
+  public Observable<Map<String, Object>> request() {
+    return request$;
+  }
+
+  public void start() {
+    for (Observable<?> o : attachObservables) subscribe(o, attachSubscriptions);
+  }
+
+  public void request(Map<String, Object> data) {
+    request$.onNext(data);
+  }
+
+  public void stop() {
+    for (Disposable s : attachSubscriptions) s.dispose();
+    attachSubscriptions.clear();
+  }
+
+  private void subscribe(Observable<?> o, List<Disposable> to) {
+    to.add(o.retryWhen(attempt -> attempt.zipWith(range(1, MAX_VALUE), (ex, cnt) -> {
+      RxJavaPlugins.getErrorHandler().accept(ex); // report exception
+      return timer(min(cnt * cnt, 100), SECONDS); // wait some time until retry
+    }).flatMap(identity())).subscribe());
+  }
+}

--- a/src/main/java/com/xemantic/githubusers/logic/presenter/SnackbarPresenter.java
+++ b/src/main/java/com/xemantic/githubusers/logic/presenter/SnackbarPresenter.java
@@ -28,22 +28,15 @@ import io.reactivex.Observable;
 
 import javax.inject.Inject;
 
-/**
- * Presenter of the {@link SnackbarView}.
- *
- * @author morisil
- */
-public class SnackbarPresenter {
+public class SnackbarPresenter extends Presenter<SnackbarView> {
 
-  private final Observable<SnackbarMessageEvent> snackbarMessage$;
+  @Inject SnackbarPresenter(
+      SnackbarView view,
+      Observable<SnackbarMessageEvent> snackbarMessage$
+  ) {
+    super(view);
 
-  @Inject
-  public SnackbarPresenter(Observable<SnackbarMessageEvent> snackbarMessage$) {
-    this.snackbarMessage$ = snackbarMessage$;
-  }
-
-  public void start(SnackbarView view) {
-    snackbarMessage$.subscribe(e -> view.show(e.getMessage()));
+    register(snackbarMessage$.doOnNext(e -> view.show(e.getMessage())));
   }
 
 }

--- a/src/main/java/com/xemantic/githubusers/logic/presenter/UserListPresenter.java
+++ b/src/main/java/com/xemantic/githubusers/logic/presenter/UserListPresenter.java
@@ -23,7 +23,6 @@
 package com.xemantic.githubusers.logic.presenter;
 
 import com.xemantic.githubusers.logic.error.ErrorAnalyzer;
-import com.xemantic.githubusers.logic.event.Trigger;
 import com.xemantic.githubusers.logic.event.UserQueryEvent;
 import com.xemantic.githubusers.logic.model.SearchResult;
 import com.xemantic.githubusers.logic.model.User;
@@ -31,53 +30,17 @@ import com.xemantic.githubusers.logic.service.UserService;
 import com.xemantic.githubusers.logic.view.UserListView;
 import com.xemantic.githubusers.logic.view.UserView;
 import io.reactivex.Observable;
-import io.reactivex.Single;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.subjects.PublishSubject;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
-/**
- * Presenter of the {@link UserListView}.
- *
- * @author morisil
- */
-public class UserListPresenter {
+public class UserListPresenter extends Presenter<UserListView> {
 
-  private final Observable<UserQueryEvent> userQuery$;
-
-  private final UserService userService;
-
-  private final ErrorAnalyzer errorAnalyzer;
-
-  private final Provider<UserView> userViewProvider;
-
-  private final Provider<UserPresenter> userPresenterProvider;
-
-  private final int userListPageSize;
-
-  private final int gitHubUserSearchLimit;
-
-  /*
-   * we don't care about synchronization of currentPage and query
-   * because these fields are supposed to be always mutated from the
-   * rendering thread of each platform (UI rendering is single-threaded everywhere)
-   */
-  private int page;
-
-  private String query;
-
-  private UserListView view;
-
-  private Disposable userQuerySubscription;
-
-  private Disposable requestSubscription;
-
-  @Inject
-  public UserListPresenter(
+  @Inject UserListPresenter(
+      UserListView view,
       Observable<UserQueryEvent> userQuery$,
       UserService userService,
       ErrorAnalyzer errorAnalyzer,
@@ -87,118 +50,57 @@ public class UserListPresenter {
       // "Only the first 1000 search results are available"
       @Named("gitHubUserSearchLimit") int gitHubUserSearchLimit
   ) {
-    this.userQuery$ = userQuery$;
-    this.userService = userService;
-    this.errorAnalyzer = errorAnalyzer;
-    this.userViewProvider = userViewProvider;
-    this.userPresenterProvider = userPresenterProvider;
-    this.userListPageSize = userListPageSize;
-    this.gitHubUserSearchLimit = gitHubUserSearchLimit;
+    super(view);
+
+    register(userQuery$.switchMap(event -> {
+      if (event.getQuery().trim().isEmpty()) {
+        return Observable.empty(); // kick out empty queries, but here so switchMap cancel previous query
+      }
+
+      return view.observeLoadMore()
+          .scanWith(() -> new Page(1, userListPageSize, gitHubUserSearchLimit), (page, n) -> page.next())
+          .flatMap(page -> {
+            view.enableLoadMore(false);
+            return userService.find(event.getQuery(), page.num, page.size)
+                .retry((cnt, ex) -> errorAnalyzer.isRecoverable(ex))
+                .doOnSuccess(result -> {
+                  if (page.num == 1) view.clear();
+                  if (page.hasMore(result)) view.enableLoadMore(true);
+
+                  for (User user : result.getItems()) {
+                    view.add(newUserView(user, userPresenterProvider.get(), userViewProvider.get()));
+                  }
+                }).toObservable();
+          });
+    }));
   }
 
-  /**
-   * Starts and initializes the presenter with given {@code view}.
-   *
-   * @param view the view.
-   */
-  public void start(UserListView view) {
-    this.view = view;
-    userQuerySubscription = userQuery$
-        .filter(event -> ! event.getQuery().trim().isEmpty()) // kick out empty queries
-        .subscribe(event -> handleNewQuery(event.getQuery()));
-  }
-
-  /**
-   * Stops this presenter. This method is supposed to be called
-   * when it is required to cancel all the pending HTTP requests, and
-   * unsubscribe from any {@link Observable}. for example when user is navigating
-   * to another {@code Activity} on Android platform.
-   */
-  public void stop() {
-    requestSubscription.dispose();
-    userQuerySubscription.dispose();
-  }
-
-  private void handleNewQuery(String query) {
-
-    prepareNewRequestStream(query);
-
-    PublishSubject<Trigger> firstTrigger = PublishSubject.create();
-
-    requestSubscription = view.observeLoadMore()
-        .mergeWith(firstTrigger)
-        .doOnNext(e -> view.enableLoadMore(false))
-        .flatMapSingle(e -> requestPage())
-        .doOnError(e -> view.enableLoadMore(true))
-        .retry((integer, throwable) -> errorAnalyzer.isRecoverable(throwable))
-        .subscribe(this::handleResult, this::handleError);
-
-    firstTrigger.onNext(Trigger.INSTANCE);
-    /*
-      This needs some explanation, in the original code the whole request
-      observable was started with Observable.just(Trigger.INSTANCE),
-      to push initial trigger, and then it was merged with the view.observeLoadMore().
-      But it didn't work as expected with the .retry() logic which is
-      resubscribing to the whole already defined observable therefore it was also
-      emitting the first trigger. For this reason I used PublishSubject to make the
-      initial trigger conditional and use it only when new query arrives.
-     */
-  }
-
-  private void prepareNewRequestStream(String query) {
-    this.query = query;
-    if (requestSubscription != null) {
-      requestSubscription.dispose();
-    }
-    page = 1;
-  }
-
-  private void afterLoadMoreEvent() {
-    view.enableLoadMore(false);
-  }
-
-  private Single<SearchResult> requestPage() {
-    return userService.find(query, page, userListPageSize);
-  }
-
-  private void handleResult(SearchResult result) {
-    if (page == 1) {
-      view.clear();
-    }
-    addUsers(result.getItems());
-    if (shouldEnableLoadMore(result)) {
-      view.enableLoadMore(true);
-    }
-    page++;
-  }
-
-  private boolean shouldEnableLoadMore(SearchResult result) {
-    int currentCount = (
-        ((page - 1) * userListPageSize)
-            + result.getItems().size()
-    );
-    return (
-        (currentCount < result.getTotalCount()) // there is more
-            && (currentCount < gitHubUserSearchLimit)
-    );
-  }
-
-  private void handleError(Throwable e) {
-    //view.enableLoadMore(true); // give it a chance to retry
-    //RxJavaHooks.onError(e); // just to log unexpected exception, is it possible to do it globally for all doOnErrors?
-  }
-
-  private void addUsers(List<User> users) {
-    for (User user : users) {
-      view.add(newUserView(user));
-    }
-  }
-
-  private UserView newUserView(User user) {
-    UserView view = userViewProvider.get();
-    UserPresenter presenter = userPresenterProvider.get();
-    presenter.start(user, view);
+  private static UserView newUserView(User user, UserPresenter presenter, UserView view) {
+    Map<String, Object> data = new HashMap<>();
+    data.put("user", user);
+    presenter.request(data);
     return view;
+  }
+
+  public static class Page {
+    public int num = 0;
+    public final int size;
+    public final int limit;
+
+    public Page(int num, int size, int limit) {
+      this.num = num;
+      this.size = size;
+      this.limit = limit;
+    }
+
+    public Page next() {
+      return new Page(num + 1, size, limit);
+    }
+
+    public boolean hasMore(SearchResult result) {
+      int currentCount = (num - 1) * size + result.getItems().size();
+      return currentCount < result.getTotalCount() /* there is more*/ && currentCount < limit;
+    }
   }
 
 }

--- a/src/main/java/com/xemantic/githubusers/logic/presenter/UserPresenter.java
+++ b/src/main/java/com/xemantic/githubusers/logic/presenter/UserPresenter.java
@@ -29,24 +29,18 @@ import com.xemantic.githubusers.logic.view.UserView;
 
 import javax.inject.Inject;
 
-/**
- * Presenter of the {@link UserView}.
- *
- * @author morisil
- */
-public class UserPresenter {
-
-  private final Sink<UserSelectedEvent> userSelectedSink;
+public class UserPresenter extends Presenter<UserView> {
 
   @Inject
-  public UserPresenter(Sink<UserSelectedEvent> userSelectedSink) {
-    this.userSelectedSink = userSelectedSink;
-  }
+  UserPresenter(
+      UserView view,
+      Sink<UserSelectedEvent> userSelectedSink
+  ) {
+    super(view);
 
-  void start(User user, UserView view) {
-    view.observeSelection()
-        .subscribe(s -> userSelectedSink.publish(new UserSelectedEvent(user)));
-    view.displayUser(user);
+    register(request().map(r -> (User) r.get("user"))
+        .doOnNext(view::displayUser)
+        .switchMap(u -> view.observeSelection().map(e -> u))
+        .doOnNext(u -> userSelectedSink.publish(new UserSelectedEvent(u))));
   }
-
 }

--- a/src/main/java/com/xemantic/githubusers/logic/presenter/UserQueryPresenter.java
+++ b/src/main/java/com/xemantic/githubusers/logic/presenter/UserQueryPresenter.java
@@ -28,24 +28,17 @@ import com.xemantic.githubusers.logic.view.UserQueryView;
 
 import javax.inject.Inject;
 
-/**
- * Presenter of the {@link UserQueryView}.
- *
- * @author morisil
- */
-public class UserQueryPresenter {
+public class UserQueryPresenter extends Presenter<UserQueryView> {
 
-  private final Sink<UserQueryEvent> userQuerySink;
+  @Inject UserQueryPresenter(
+      UserQueryView view,
+      Sink<UserQueryEvent> userQuerySink
+  ) {
+    super(view);
 
-  @Inject
-  public UserQueryPresenter(Sink<UserQueryEvent> userQuerySink) {
-    this.userQuerySink = userQuerySink;
-  }
-
-  public void start(UserQueryView view) {
-    view.observeQueryInput().subscribe(query ->
-        userQuerySink.publish(new UserQueryEvent(query))
-    );
+    register(view.observeQueryInput()
+        .map(UserQueryEvent::new)
+        .doOnNext(userQuerySink::publish));
   }
 
 }


### PR DESCRIPTION
We have been using rx with GWTP and this is how we are using right now. In general, subscribing to an observable is pretty dangerous I to spread subscription over the code is not a good idea. Observables have a pretty big difference with traditional events (gwt ui events for example), if an error happens, the subscriptions die! so to avoid what you need to do is to create some kind of scope and register the observable so the "scope" manages the subscription.

This matches perfectly with the component model, in our case gwt widgets and gwtp (or your custom) presenter are 2 kinds of components. And binding the lifecycle of this component to the subscription of the observables works perfectly. If you need to use it in a widget you can use RxGWT RxWidget, and I have created here a base Presenter which binds the start/stop lifecycle with the subscription of the registered observables. In GWTP with have different kind of subscription for bind/unbind and reveal/hide. Also, there is an observable called request() that just notifies when a request is pushed to the presenter (all this is based on GWTP but your lib seems to match).

This has weird results, usually, you end up doing everything in the constructor (but it is lazy, don't worry, the constructor is still lightweight, means run quickly, do almost nothing! even if it has a lot of code) and you usually don't need any field. You end up with a list of register call which actually describes the behavior of the presenter usually, (when something happens) -> (then do this thing).

This PR is not ready to be merged, and I need to update the test, but I just upload so you might see if you like it or not and if you see that this way it should be safer to develop.